### PR TITLE
feat: Larry-inspired learning loop with planner, analyzer, social dis…

### DIFF
--- a/.github/workflows/approve.yml
+++ b/.github/workflows/approve.yml
@@ -1,0 +1,93 @@
+name: "Bekku: Handle Approval"
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  handle-comment:
+    # Only run on Bekku draft issues, only for repo owner
+    if: |
+      contains(github.event.issue.labels.*.name, 'bekku-draft') &&
+      github.event.comment.user.login == github.repository_owner
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Determine action from comment
+        id: parse
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
+        run: |
+          COMMENT_LOWER=$(echo "$COMMENT_BODY" | tr '[:upper:]' '[:lower:]' | head -1)
+          if echo "$COMMENT_LOWER" | grep -q "^approve"; then
+            echo "action=approve" >> $GITHUB_OUTPUT
+          elif echo "$COMMENT_LOWER" | grep -q "^reject"; then
+            echo "action=reject" >> $GITHUB_OUTPUT
+          elif echo "$COMMENT_LOWER" | grep -q "^engagement:"; then
+            echo "action=engagement" >> $GITHUB_OUTPUT
+          else
+            echo "action=edit" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Handle approval
+        if: steps.parse.outputs.action == 'approve'
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPO: ${{ github.repository }}
+        run: |
+          python run_approve.py \
+            --issue ${{ github.event.issue.number }} \
+            --action approve
+
+      - name: Handle rejection
+        if: steps.parse.outputs.action == 'reject'
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPO: ${{ github.repository }}
+        run: |
+          python run_approve.py \
+            --issue ${{ github.event.issue.number }} \
+            --action reject
+
+      - name: Handle edit
+        if: steps.parse.outputs.action == 'edit'
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPO: ${{ github.repository }}
+        run: |
+          python run_approve.py \
+            --issue ${{ github.event.issue.number }} \
+            --action edit \
+            --draft "${{ github.event.comment.body }}"
+
+      - name: Handle engagement
+        if: steps.parse.outputs.action == 'engagement'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPO: ${{ github.repository }}
+        run: |
+          python run_approve.py \
+            --issue ${{ github.event.issue.number }} \
+            --action engagement \
+            --comment "${{ github.event.comment.body }}"
+
+      - name: Commit skill updates
+        if: always()
+        run: |
+          git config user.name "Bekku Agent"
+          git config user.email "bekku-agent@users.noreply.github.com"
+          git pull --rebase
+          git add skills/
+          git diff --cached --quiet || git commit -m "chore: update skills after approval"
+          git push

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -1,0 +1,48 @@
+name: "Bekku: Generate Content"
+
+on:
+  schedule:
+    # Run daily at 9am UTC (Mon-Fri)
+    - cron: "0 9 * * 1-5"
+  workflow_dispatch:
+    inputs:
+      task:
+        description: "Specific task (leave empty for auto-pick from queue)"
+        required: false
+      batch:
+        description: "Number of tasks to run"
+        required: false
+        default: "1"
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Generate content draft
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPO: ${{ github.repository }}
+        run: |
+          if [ -n "${{ github.event.inputs.task }}" ]; then
+            python run_scheduled.py --task "${{ github.event.inputs.task }}"
+          else
+            python run_scheduled.py --batch ${{ github.event.inputs.batch || '1' }}
+          fi
+
+      - name: Commit schedule updates
+        run: |
+          git config user.name "Bekku Agent"
+          git config user.email "bekku-agent@users.noreply.github.com"
+          git add schedule.yaml skills/
+          git diff --cached --quiet || git commit -m "chore: update schedule and skills after content generation"
+          git push

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,198 @@
+# Bekku: Deploy-Ready Learning System (Larry-Inspired)
+
+## Context
+From the Larry/Oliver podcast, the key insight is: **Larry's power isn't content creation — it's the learning loop.** Larry creates content → posts → reads analytics → learns what works → iterates → compounds. The skill file grows with every run. Failures become rules. Wins become formulas. That's why it works.
+
+Bekku currently generates content but doesn't learn or iterate. We need to make it a self-improving system that gets smarter with every run — just like Larry.
+
+## Larry's Architecture (from LarryBrain skill file + podcast)
+1. **Skill files are the brain** — 500+ lines encoding every failure and every win
+2. **The Larry Loop:** Content → Distribute → Measure → Learn → Iterate
+3. **Diagnostic Decision Matrix** (core learning logic):
+   - High views + High conversion → Scale immediately (3 variations)
+   - High views + Low conversion → Fix CTA (hook works, downstream broken)
+   - Low views + High conversion → Fix hooks (content converts, visibility lacks)
+   - Low views + Low conversion → Full reset (try different format)
+4. **8-phase onboarding** — profile app, research competitors, select format, configure tracking, THEN create
+5. **Structured per-post tracking** — date, hook text, category, views, engagement, conversions, CTA used
+6. **Daily cron analytics** — automated performance analysis and recommendations
+7. **RevenueCat attribution** — correlates content timestamps with RC revenue events
+8. **HIL for publishing** — posts as draft, operator adds music + publishes (~60 seconds)
+9. **Memory files per project** — persistent, portable, restorable
+
+## What Bekku Is Missing vs Larry
+
+| Larry Has | Bekku Has | Gap |
+|-----------|-----------|-----|
+| Analytics feedback loop (TikTok + RC) | None | Need to track gist engagement + learn from it |
+| Skill file that grows with every run | Basic append after each run | Need structured win/loss logging with actionable rules |
+| Cron-triggered runs | Manual runs only | Need scheduled content production |
+| Iterates on content format | Generates fresh each time | Need to feed past performance back into prompts |
+| Brainstorms with operator | Only takes task input | Need interactive brainstorm mode |
+| Posts as drafts → operator publishes | Full auto-publish after approval | This is fine — similar pattern |
+
+---
+
+## New LangGraph Architecture
+
+### Current (linear pipeline):
+```
+router → researcher → writer → ⏸ approval → publisher → reporter
+```
+
+### Proposed (learning loop with planner + analyzer):
+```
+planner → router → researcher → writer → ⏸ approval → publisher → analyzer
+   ▲                                                                   │
+   └──────────── skills/*.md (compounding knowledge) ◄─────────────────┘
+```
+
+### New Nodes:
+
+**Planner Node** (runs BEFORE router):
+- Reads all skill files (past performance, failures, RC knowledge, competitive landscape)
+- Reads `skills/content-performance.md` to see what topics have been covered, what worked
+- Enriches the task with strategic context: "We've published 3 paywall articles. Diversify into webhooks. Last Flutter article got edited heavily — avoid placeholder code."
+- Adds `plan` field to state that the writer uses as additional guidance
+- For scheduled/autonomous runs: planner PICKS the topic itself based on gaps
+
+**Analyzer Node** (replaces reporter):
+- Runs after publisher
+- Logs structured outcome to `skills/content-performance.md`:
+  - Task, topic, format, sources used, draft length
+  - Published URL
+  - Approval status (approved / edited / rejected)
+  - If edited: what changed (compare original draft vs final)
+  - Rule extracted: "Hook X worked for topic Y" or "Placeholder code got rejected — always use real SDK methods"
+- Updates `skills/failure-log.md` with actionable rules on rejection
+- Updates `skills/revenuecat-knowledge.md` with new facts learned during research
+- This is the "Larry Loop closer" — every run teaches the next run
+
+### State Changes (`src/state.py`):
+```python
+@dataclass
+class AgentState:
+    task: str = ""
+    task_type: str = ""
+    plan: str = ""              # NEW: planner output — strategic guidance for writer
+    research_context: str = ""
+    sources: list[str] = field(default_factory=list)
+    draft: str = ""
+    published_url: str = ""
+    activity_log: list[dict[str, Any]] = field(default_factory=list)
+    error: str = ""
+```
+
+### Graph Edges:
+```python
+graph.set_entry_point("planner")
+graph.add_edge("planner", "router")
+graph.add_conditional_edges("router", _route_after_router, {"researcher": "researcher", "writer": "writer"})
+graph.add_edge("researcher", "writer")
+graph.add_conditional_edges("writer", _route_after_writer, {"approval": "approval", "analyzer": "analyzer"})
+graph.add_conditional_edges("approval", _route_after_approval, {"publisher": "publisher", "analyzer": "analyzer"})
+graph.add_edge("publisher", "analyzer")
+graph.set_finish_point("analyzer")
+```
+
+Interactive: `planner → router → researcher (lightweight) → writer → analyzer`
+Content:     `planner → router → researcher → writer → ⏸ approval → publisher → analyzer`
+
+---
+
+## Implementation Plan
+
+### Phase 1: Save Larry Playbook as Skill (5 min)
+
+`skills/larry-playbook.md` — NEW file encoding patterns from the actual Larry Marketing skill (via LarryBrain API):
+- The Larry Loop: create → distribute → measure → learn → iterate
+- Diagnostic Decision Matrix (high/low views × high/low conversion → action)
+- Structured per-post tracking: date, hook, category, views, engagement, conversions, CTA
+- 8-phase onboarding pattern (profile → research → format → tracking → create)
+- Daily cron analytics with automated recommendations
+- Iterate on winners (3 variations), full reset on double-lows
+- Skill files compound — every failure becomes a rule
+
+Source: `https://www.larrybrain.com/api/skills/install?slug=larry-marketing&mode=files`
+
+### Phase 2: Add Planner Node (30 min)
+
+**New files:**
+- `src/nodes/planner.py` — loads skill files, analyzes past performance, outputs strategic guidance
+- `src/prompts/planner.md` — system prompt for the planner
+
+**Changes:**
+- `src/state.py` — add `plan: str = ""` field
+- `src/graph.py` — add planner as entry point, wire edges
+- `src/nodes/writer.py` — include `state.plan` in user message to writer
+- `src/tools/skills.py` — add planner to NODE_SKILLS (loads everything)
+- `skills/content-performance.md` — NEW file for tracking published content outcomes
+
+### Phase 3: Replace Reporter with Analyzer Node (30 min)
+
+**Changes:**
+- `src/nodes/reporter.py` → rename/rewrite as `src/nodes/analyzer.py`
+- Structured outcome logging (task, topic, URL, approval status, rules learned)
+- Append to `skills/content-performance.md` with outcome data
+- Append to `skills/failure-log.md` with actionable rules on rejection
+- `src/graph.py` — swap reporter for analyzer in graph
+- `app.py` — update imports
+
+### Phase 4: Fix Interactive Mode (15 min)
+
+- `src/graph.py` — route interactive through researcher (all tasks go through planner → router → researcher now)
+- `src/nodes/researcher.py` — lightweight path for interactive (llms.txt only, no URL picking)
+- `src/prompts/interactive.md` — tell writer about research context
+
+### Phase 5: Add Scheduled Runs (30 min)
+
+**New files:**
+- `run_scheduled.py` — cron runner that uses planner to auto-pick topics
+- `schedule.yaml` — config for autonomous runs
+
+### Phase 6: Ship Content (2-3 hrs)
+
+Run 5 diverse articles + 1 product feedback + 1 weekly report through the updated pipeline.
+
+### Phase 7: Distribution (MK manual)
+
+LinkedIn + X posts sharing published content.
+
+---
+
+## Execution Order
+1. **Phase 1** — Larry playbook skill file (5 min)
+2. **Phase 2** — Planner node (30 min)
+3. **Phase 3** — Analyzer node (30 min)
+4. **Phase 4** — Interactive mode fix (15 min)
+5. **Phase 5** — Scheduled runs (30 min)
+6. **Phase 6** — Ship content (2-3 hrs)
+7. **Phase 7** — Distribution (MK manual)
+
+## Files Summary
+
+### New files:
+- `src/nodes/planner.py`
+- `src/nodes/analyzer.py`
+- `src/prompts/planner.md`
+- `skills/larry-playbook.md`
+- `skills/content-performance.md`
+- `run_scheduled.py`
+- `schedule.yaml`
+
+### Modified files:
+- `src/state.py` — add `plan` field
+- `src/graph.py` — new graph topology with planner + analyzer
+- `src/nodes/writer.py` — use `state.plan` in prompt
+- `src/nodes/researcher.py` — lightweight interactive path
+- `src/tools/skills.py` — update NODE_SKILLS for planner + analyzer
+- `src/prompts/interactive.md` — mention research context
+- `app.py` — update imports for new graph
+
+## Target End State
+- **Bekku learns from every run** — analyzer logs outcomes, planner reads them
+- **Content strategy is data-driven** — planner picks topics based on gaps and performance
+- **Interactive mode is grounded** — answers reference real RC docs
+- **Autonomous operation** — cron + planner means Bekku can run unsupervised
+- **12+ diverse published gists** with structured performance tracking
+- **Deploy-ready** — anyone can clone, configure, run

--- a/app.py
+++ b/app.py
@@ -9,7 +9,7 @@ from uuid import uuid4
 import streamlit as st
 from dotenv import load_dotenv
 from langgraph.checkpoint.memory import MemorySaver
-from langgraph.graph import StateGraph
+from langgraph.graph import END, StateGraph
 from langgraph.types import Command
 
 from src.graph import (
@@ -21,9 +21,11 @@ from src.graph import (
     research,
     write,
     publish,
-    report,
 )
+from src.nodes.analyzer import analyze
+from src.nodes.planner import plan
 from src.state import AgentState
+from src.tools.skills import log_engagement
 
 load_dotenv()
 
@@ -40,18 +42,19 @@ st.set_page_config(
 def get_graph():
     graph = StateGraph(AgentState)
     graph.add_node("router", route)
+    graph.add_node("planner", plan)
     graph.add_node("researcher", research)
     graph.add_node("writer", write)
     graph.add_node("approval", approve)
     graph.add_node("publisher", publish)
-    graph.add_node("reporter", report)
+    graph.add_node("analyzer", analyze)
     graph.set_entry_point("router")
-    graph.add_conditional_edges("router", _route_after_router, {"researcher": "researcher", "writer": "writer"})
+    graph.add_conditional_edges("router", _route_after_router, {"planner": "planner", "researcher": "researcher"})
+    graph.add_edge("planner", "researcher")
     graph.add_edge("researcher", "writer")
-    graph.add_conditional_edges("writer", _route_after_writer, {"approval": "approval", "reporter": "reporter"})
-    graph.add_conditional_edges("approval", _route_after_approval, {"publisher": "publisher", "reporter": "reporter"})
-    graph.add_edge("publisher", "reporter")
-    graph.set_finish_point("reporter")
+    graph.add_conditional_edges("writer", _route_after_writer, {"approval": "approval", END: END})
+    graph.add_conditional_edges("approval", _route_after_approval, {"publisher": "publisher", "analyzer": "analyzer"})
+    graph.add_edge("publisher", "analyzer")
     return graph.compile(checkpointer=MemorySaver())
 
 
@@ -131,24 +134,55 @@ if st.session_state.pending_approval is not None:
     st.header("Review & Approve")
     st.caption(f"{len(approval['draft'].split()):,} words · Publishing to GitHub Gist")
 
-    # Side-by-side: edit markdown on the left, live preview on the right
-    col_edit, col_preview = st.columns(2)
+    # Tabs: Article | Social Posts
+    tab_article, tab_social = st.tabs(["Article", "Social Posts"])
 
-    with col_edit:
-        st.markdown("**Edit**")
-        edited_draft = st.text_area(
-            "Markdown editor",
-            value=approval["draft"],
-            height=500,
-            key="draft_editor",
-            label_visibility="collapsed",
-        )
+    with tab_article:
+        # Side-by-side: edit markdown on the left, live preview on the right
+        col_edit, col_preview = st.columns(2)
 
-    with col_preview:
-        st.markdown("**Preview**")
-        preview_container = st.container(height=500, border=True)
-        with preview_container:
-            st.markdown(st.session_state.get("draft_editor", approval["draft"]))
+        with col_edit:
+            st.markdown("**Edit**")
+            edited_draft = st.text_area(
+                "Markdown editor",
+                value=approval["draft"],
+                height=500,
+                key="draft_editor",
+                label_visibility="collapsed",
+            )
+
+        with col_preview:
+            st.markdown("**Preview**")
+            preview_container = st.container(height=500, border=True)
+            with preview_container:
+                st.markdown(st.session_state.get("draft_editor", approval["draft"]))
+
+    with tab_social:
+        social = approval.get("social_posts", {})
+        if social:
+            st.caption("Copy these after publishing. [GIST_URL] will be replaced with the real link.")
+
+            if social.get("x"):
+                st.markdown("**X (Twitter)**")
+                st.text_area(
+                    "X post",
+                    value=social["x"],
+                    height=150,
+                    key="social_x_editor",
+                    label_visibility="collapsed",
+                )
+
+            if social.get("linkedin"):
+                st.markdown("**LinkedIn**")
+                st.text_area(
+                    "LinkedIn post",
+                    value=social["linkedin"],
+                    height=200,
+                    key="social_linkedin_editor",
+                    label_visibility="collapsed",
+                )
+        else:
+            st.info("No social posts generated for this task.")
 
     # Actions
     col1, col2, col3 = st.columns([2, 1, 1])
@@ -179,6 +213,20 @@ if st.session_state.pending_approval is not None:
             if url:
                 st.balloons()
                 st.success(f"Published! [Open Gist →]({url})")
+
+                # Show social posts with real URL filled in
+                social = approval.get("social_posts", {})
+                if social:
+                    st.divider()
+                    st.markdown("**Ready to post — copy below:**")
+                    if social.get("x"):
+                        x_text = st.session_state.get("social_x_editor", social["x"]).replace("[GIST_URL]", url)
+                        st.markdown("**X (Twitter)**")
+                        st.code(x_text, language=None)
+                    if social.get("linkedin"):
+                        li_text = st.session_state.get("social_linkedin_editor", social["linkedin"]).replace("[GIST_URL]", url)
+                        st.markdown("**LinkedIn**")
+                        st.code(li_text, language=None)
             else:
                 st.warning("Publish completed but no URL returned. Check `GITHUB_TOKEN`.")
             st.rerun()
@@ -249,6 +297,49 @@ else:
         key="task_area",
     )
 
+    # --- Engagement Tracking ---
+    published_runs = [r for r in st.session_state.runs if r.get("published_url")]
+    if published_runs:
+        with st.expander("Log LinkedIn Engagement"):
+            st.caption("Select a published piece and enter LinkedIn metrics to close the learning loop.")
+
+            run_labels = {
+                r["task"][:60]: r["published_url"] for r in published_runs
+            }
+            selected_label = st.selectbox(
+                "Published content",
+                options=list(run_labels.keys()),
+                key="engagement_select",
+            )
+            selected_url = run_labels.get(selected_label, "")
+
+            li_url = st.text_input("LinkedIn post URL", key="li_url")
+            col_i, col_l, col_c, col_s = st.columns(4)
+            with col_i:
+                impressions = st.number_input("Impressions", min_value=0, value=0, key="li_impressions")
+            with col_l:
+                likes = st.number_input("Likes", min_value=0, value=0, key="li_likes")
+            with col_c:
+                comments = st.number_input("Comments", min_value=0, value=0, key="li_comments")
+            with col_s:
+                shares = st.number_input("Shares", min_value=0, value=0, key="li_shares")
+
+            if st.button("Save Engagement", key="save_engagement"):
+                if selected_url and li_url:
+                    log_engagement(
+                        published_url=selected_url,
+                        linkedin_url=li_url,
+                        impressions=impressions,
+                        likes=likes,
+                        comments=comments,
+                        shares=shares,
+                    )
+                    st.success("Engagement logged! Planner will use this data in the next run.")
+                else:
+                    st.warning("Enter a LinkedIn URL first.")
+
+        st.divider()
+
     if st.button("🚀 Run", type="primary", disabled=not task):
         thread_id = str(uuid4())
         config = {"configurable": {"thread_id": thread_id}}
@@ -282,6 +373,7 @@ else:
                     "task": task,
                     "task_type": task_type,
                     "draft": state_values.get("draft", ""),
+                    "social_posts": state_values.get("social_posts", {}),
                     "sources": sources,
                     "research_context": state_values.get("research_context", ""),
                     "thread_id": thread_id,

--- a/run_approve.py
+++ b/run_approve.py
@@ -1,0 +1,204 @@
+"""Bekku — Issue approval handler for GitHub Actions.
+
+Called when MK comments on a Bekku draft issue.
+Reads the comment, publishes to gist if approved, runs the analyzer,
+and comments back with the final social posts.
+
+Usage:
+    python run_approve.py --issue 42 --action approve
+    python run_approve.py --issue 42 --action reject
+    python run_approve.py --issue 42 --action edit --draft "edited content..."
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import re
+
+from dotenv import load_dotenv
+from github import Github
+
+load_dotenv()
+
+
+def get_repo():
+    token = os.environ["GITHUB_TOKEN"]
+    repo_name = os.environ.get("GITHUB_REPO", "bekku-agent/bekku-agent")
+    gh = Github(token)
+    return gh.get_repo(repo_name)
+
+
+def extract_draft_from_issue(body: str) -> str:
+    """Extract the draft markdown from the issue body (between the --- markers)."""
+    parts = body.split("---")
+    if len(parts) >= 3:
+        # The draft is between the first and second --- after the metadata
+        return parts[2].strip()
+    return body
+
+
+def extract_social_from_issue(body: str) -> dict[str, str]:
+    """Extract social posts from the issue body."""
+    social = {}
+    # Extract X post
+    x_match = re.search(r"### X \(Twitter\)\n```\n(.*?)\n```", body, re.DOTALL)
+    if x_match:
+        social["x"] = x_match.group(1)
+    # Extract LinkedIn post
+    li_match = re.search(r"### LinkedIn\n```\n(.*?)\n```", body, re.DOTALL)
+    if li_match:
+        social["linkedin"] = li_match.group(1)
+    return social
+
+
+def extract_task_from_issue(title: str) -> str:
+    """Extract the original task from the issue title."""
+    return title.replace("[Bekku Draft] ", "")
+
+
+async def handle_approve(issue_number: int, action: str, edited_draft: str | None = None):
+    """Handle an approval action on a draft issue."""
+    from src.nodes.analyzer import analyze
+    from src.nodes.publisher import publish
+    from src.state import AgentState
+
+    repo = get_repo()
+    issue = repo.get_issue(issue_number)
+
+    task = extract_task_from_issue(issue.title)
+    draft = edited_draft or extract_draft_from_issue(issue.body)
+    social = extract_social_from_issue(issue.body)
+
+    if action == "reject":
+        # Log rejection and close
+        state = AgentState(
+            task=task,
+            task_type="content",
+            draft="[Rejected by operator]",
+            error="Draft rejected by operator",
+        )
+        await analyze(state)
+
+        issue.create_comment("Draft rejected. Logged to failure-log.md for learning.")
+        issue.remove_from_labels("awaiting-review")
+        issue.add_to_labels("rejected")
+        issue.edit(state="closed")
+        print(f"Issue #{issue_number} rejected and closed.")
+        return
+
+    # Approve or edit → publish
+    state = AgentState(
+        task=task,
+        task_type="content",
+        draft=draft,
+        social_posts=social,
+    )
+
+    # Publish to gist
+    state = await publish(state)
+
+    if not state.published_url:
+        issue.create_comment(f"Publish failed: {state.error}")
+        return
+
+    # Run analyzer to log outcome
+    await analyze(state)
+
+    # Build comment with social posts (URL filled in)
+    comment_parts = [
+        f"Published! {state.published_url}\n",
+    ]
+
+    if social:
+        comment_parts.append("---\n**Social posts ready to copy:**\n")
+        if social.get("x"):
+            x_text = social["x"].replace("[GIST_URL]", state.published_url)
+            comment_parts.append(f"**X (Twitter)**\n```\n{x_text}\n```\n")
+        if social.get("linkedin"):
+            li_text = social["linkedin"].replace("[GIST_URL]", state.published_url)
+            comment_parts.append(f"**LinkedIn**\n```\n{li_text}\n```\n")
+
+    comment_parts.append(
+        "\n---\n"
+        "After posting to LinkedIn, come back and comment with engagement numbers:\n"
+        "`engagement: <linkedin_url> <impressions> <likes> <comments> <shares>`"
+    )
+
+    issue.create_comment("\n".join(comment_parts))
+    issue.remove_from_labels("awaiting-review")
+    issue.add_to_labels("published")
+    issue.edit(state="closed")
+    print(f"Issue #{issue_number} published: {state.published_url}")
+
+
+async def handle_engagement(issue_number: int, comment_body: str):
+    """Parse an engagement comment and log it."""
+    from src.tools.skills import log_engagement
+
+    # Expected format: engagement: <linkedin_url> <impressions> <likes> <comments> <shares>
+    match = re.match(
+        r"engagement:\s*(\S+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)",
+        comment_body.strip(),
+    )
+    if not match:
+        print(f"Could not parse engagement from: {comment_body}")
+        return
+
+    linkedin_url = match.group(1)
+    impressions = int(match.group(2))
+    likes = int(match.group(3))
+    comments = int(match.group(4))
+    shares = int(match.group(5))
+
+    repo = get_repo()
+    issue = repo.get_issue(issue_number)
+    task = extract_task_from_issue(issue.title)
+
+    # Find the published URL from the issue comments
+    published_url = ""
+    for comment in issue.get_comments():
+        if "Published!" in comment.body:
+            url_match = re.search(r"(https://gist\.github\.com/\S+)", comment.body)
+            if url_match:
+                published_url = url_match.group(1)
+                break
+
+    if not published_url:
+        print("Could not find published URL in issue comments")
+        return
+
+    log_engagement(
+        published_url=published_url,
+        linkedin_url=linkedin_url,
+        impressions=impressions,
+        likes=likes,
+        comments=comments,
+        shares=shares,
+    )
+
+    issue.create_comment(
+        f"Engagement logged! {impressions} impressions, {likes} likes, "
+        f"{comments} comments, {shares} shares. "
+        f"Planner will use this data in the next content run."
+    )
+    print(f"Engagement logged for issue #{issue_number}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Bekku issue approval handler")
+    parser.add_argument("--issue", type=int, required=True, help="Issue number")
+    parser.add_argument("--action", type=str, required=True, help="approve|reject|edit|engagement")
+    parser.add_argument("--draft", type=str, help="Edited draft content (for edit action)")
+    parser.add_argument("--comment", type=str, help="Raw comment body (for engagement)")
+    args = parser.parse_args()
+
+    if args.action == "engagement":
+        asyncio.run(handle_engagement(args.issue, args.comment or ""))
+    else:
+        asyncio.run(handle_approve(args.issue, args.action, args.draft))
+
+
+if __name__ == "__main__":
+    main()

--- a/run_scheduled.py
+++ b/run_scheduled.py
@@ -1,0 +1,170 @@
+"""Bekku — Headless content runner for GitHub Actions deployment.
+
+Runs the pipeline up to the draft stage (planner → researcher → writer),
+then creates a GitHub Issue with the draft + social posts for MK to review.
+
+Usage:
+    python run_scheduled.py                    # Run one auto-picked task
+    python run_scheduled.py --task "..."       # Run a specific task
+    python run_scheduled.py --batch 3          # Run 3 auto-picked tasks
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+from pathlib import Path
+
+import yaml
+from dotenv import load_dotenv
+from github import Github
+
+load_dotenv()
+
+SCHEDULE_PATH = Path(__file__).parent / "schedule.yaml"
+
+
+def load_schedule() -> dict:
+    if SCHEDULE_PATH.exists():
+        return yaml.safe_load(SCHEDULE_PATH.read_text()) or {}
+    return {}
+
+
+def get_topic_queue(schedule: dict) -> list[str]:
+    return schedule.get("topic_queue", [])
+
+
+async def generate_draft(task: str) -> dict:
+    """Run planner → router → researcher → writer (no approval/publish)."""
+    from openai import AsyncOpenAI
+
+    from src.nodes.planner import plan
+    from src.nodes.researcher import research
+    from src.nodes.router import route
+    from src.nodes.writer import write
+    from src.state import AgentState
+
+    state = AgentState(task=task)
+
+    # Run the pipeline nodes directly — no graph interrupt needed
+    state = await route(state)
+    if state.task_type != "interactive":
+        state = await plan(state)
+    state = await research(state)
+    state = await write(state)
+
+    return {
+        "task": state.task,
+        "task_type": state.task_type,
+        "draft": state.draft,
+        "social_posts": state.social_posts,
+        "sources": state.sources,
+        "plan": state.plan,
+        "error": state.error,
+    }
+
+
+def create_review_issue(result: dict) -> str:
+    """Create a GitHub Issue with the draft for MK to review."""
+    token = os.environ["GITHUB_TOKEN"]
+    repo_name = os.environ.get("GITHUB_REPO", "bekku-agent/bekku-agent")
+
+    gh = Github(token)
+    repo = gh.get_repo(repo_name)
+
+    task = result["task"]
+    draft = result["draft"]
+    social = result["social_posts"]
+    sources = result["sources"]
+
+    # Build issue body
+    body_parts = [
+        "## Draft for Review\n",
+        f"**Task:** {task}\n",
+        f"**Type:** {result['task_type']}\n",
+        f"**Sources:** {len(sources)}\n",
+        "---\n",
+        draft,
+        "\n---\n",
+    ]
+
+    if social:
+        body_parts.append("## Social Posts\n")
+        if social.get("x"):
+            body_parts.append(f"### X (Twitter)\n```\n{social['x']}\n```\n")
+        if social.get("linkedin"):
+            body_parts.append(f"### LinkedIn\n```\n{social['linkedin']}\n```\n")
+
+    body_parts.append(
+        "\n---\n"
+        "**Actions:** Comment on this issue to proceed:\n"
+        "- `approve` — publish as-is to GitHub Gist\n"
+        "- `reject` — skip publishing, log rejection\n"
+        "- Paste edited markdown — publish the edited version\n"
+    )
+
+    body = "\n".join(body_parts)
+
+    # Create issue
+    title = f"[Bekku Draft] {task[:80]}"
+    issue = repo.create_issue(
+        title=title,
+        body=body,
+        labels=["bekku-draft", "awaiting-review"],
+    )
+
+    print(f"  → Issue created: {issue.html_url}")
+    return issue.html_url
+
+
+async def run_one(task: str) -> None:
+    """Generate a draft and create a review issue."""
+    print(f"Generating draft for: {task[:80]}")
+    result = await generate_draft(task)
+
+    if result["error"]:
+        print(f"  → Error: {result['error']}")
+        return
+
+    create_review_issue(result)
+
+
+async def run_batch(count: int) -> None:
+    """Run multiple tasks from the queue or auto-pick."""
+    schedule = load_schedule()
+    topic_queue = get_topic_queue(schedule)
+
+    for i in range(count):
+        if topic_queue:
+            task = topic_queue.pop(0)
+            print(f"\n[{i+1}/{count}] Queued topic: {task[:80]}")
+        else:
+            task = (
+                "Auto-pick a topic: analyze content gaps in skills/content-performance.md "
+                "and write about an uncovered RevenueCat topic. Diversify from past content."
+            )
+            print(f"\n[{i+1}/{count}] Autonomous topic selection")
+
+        await run_one(task)
+
+    # Update schedule with remaining queue
+    if schedule:
+        schedule["topic_queue"] = topic_queue
+        SCHEDULE_PATH.write_text(yaml.dump(schedule, default_flow_style=False))
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Bekku headless content runner")
+    parser.add_argument("--task", type=str, help="Specific task to run")
+    parser.add_argument("--batch", type=int, default=1, help="Number of tasks to run")
+    args = parser.parse_args()
+
+    if args.task:
+        asyncio.run(run_one(args.task))
+    else:
+        asyncio.run(run_batch(args.batch))
+
+
+if __name__ == "__main__":
+    main()

--- a/schedule.yaml
+++ b/schedule.yaml
@@ -1,0 +1,30 @@
+# Bekku — Scheduled content configuration
+# Topics are picked from the queue first, then the planner auto-selects based on gaps.
+
+# Pre-planned topic queue (processed in order, removed after each run)
+topic_queue:
+  - "Write a tutorial on implementing A/B test paywalls with RevenueCat Experiments"
+  - "Write a guide on setting up RevenueCat webhooks for server-side subscription tracking"
+  - "Write a tutorial on migrating from StoreKit 1 to StoreKit 2 with RevenueCat"
+  - "Write a case study on using RevenueCat entitlements for feature gating patterns"
+  - "Write a guide on integrating RevenueCat with a Flutter app — from zero to first purchase"
+  - "What could RevenueCat improve about their MCP server developer experience?"
+  - "Write a weekly report summarizing Bekku's published content, learnings, and next steps"
+
+# Autonomous mode settings
+autonomous:
+  enabled: true
+  # Categories to diversify across
+  categories:
+    - tutorial
+    - case-study
+    - guide
+    - feedback
+    - opinion
+  # Platforms to cover
+  platforms:
+    - iOS/Swift
+    - Android/Kotlin
+    - Flutter/Dart
+    - React Native/TypeScript
+    - Web/TypeScript

--- a/skills/content-performance.md
+++ b/skills/content-performance.md
@@ -1,0 +1,23 @@
+# Content Performance Log
+
+Structured tracking of every published piece. The planner reads this to inform content strategy.
+
+## Format
+```
+### [Date] — [Title/Topic]
+- **Category:** tutorial | case-study | feedback | guide | opinion | application
+- **Format:** gist | blog | thread
+- **Sources:** N sources used
+- **Draft length:** N chars
+- **Approval:** approved | edited | rejected
+- **Published URL:** url or N/A
+- **LinkedIn URL:** url or N/A
+- **LinkedIn Engagement:** impressions / likes / comments / shares or pending
+- **Rule learned:** actionable takeaway
+```
+
+## Topics Covered
+<!-- Updated by analyzer after each run -->
+
+## Entries
+<!-- Appended by analyzer after each run -->

--- a/skills/larry-playbook.md
+++ b/skills/larry-playbook.md
@@ -1,0 +1,50 @@
+# Larry Playbook — Learning Loop Patterns
+
+Encoded from the Larry Marketing AI agent (LarryBrain). These patterns drive Bekku's self-improving content strategy.
+
+## The Larry Loop
+
+Content → Distribute → Measure → Learn → Iterate
+
+Every run teaches the next run. Skill files compound — every failure becomes a rule, every win becomes a formula.
+
+## Diagnostic Decision Matrix
+
+When evaluating past content performance:
+
+| Views | Conversion | Action |
+|-------|-----------|--------|
+| High  | High      | **Scale immediately** — create 3 variations on this topic/format |
+| High  | Low       | **Fix CTA** — hook works but downstream is broken. Change call-to-action, restructure conclusion |
+| Low   | High      | **Fix hooks** — content converts but lacks visibility. Rewrite title/intro, try different distribution |
+| Low   | Low       | **Full reset** — try completely different format, topic, or angle |
+
+## Structured Per-Post Tracking
+
+Every published piece must log:
+- Date published
+- Hook/title text
+- Topic category (tutorial, case study, feedback, guide, opinion)
+- Format (blog post, gist, thread)
+- Sources used
+- Draft length
+- Approval status (approved / edited / rejected)
+- What was edited (if applicable)
+
+## Content Strategy Principles
+
+1. **Profile first** — understand the target audience (RC developers) before creating
+2. **Research competitors** — know what Superwall, Adapty, Qonversion are publishing
+3. **Select format** — match format to topic (tutorials for SDKs, case studies for patterns)
+4. **Configure tracking** — set up measurement before publishing
+5. **Then create** — only write after steps 1-4
+6. **Diversify topics** — don't repeat the same topic. Cover: paywalls, webhooks, entitlements, experiments, analytics, migration, SDKs (iOS/Android/Flutter/React Native)
+7. **Iterate on winners** — when something works, create variations
+8. **Full reset on double-lows** — don't iterate on content that neither gets views nor converts
+
+## Skill File Rules
+
+- Skill files are the brain — they must grow with every run
+- Failures are more valuable than successes (they prevent future mistakes)
+- Be specific in rules — "avoid placeholder code" is better than "write better code"
+- Track what the operator edited — that's implicit feedback on quality

--- a/src/graph.py
+++ b/src/graph.py
@@ -1,4 +1,10 @@
-"""Bekku — LangGraph orchestrator with intent routing and human-in-the-loop approval."""
+"""Bekku — LangGraph orchestrator with learning loop, intent routing, and human-in-the-loop approval.
+
+Architecture (Larry-inspired learning loop):
+  planner → router → researcher → writer → ⏸ approval → publisher → analyzer
+     ▲                                                                   │
+     └──────────── skills/*.md (compounding knowledge) ◄─────────────────┘
+"""
 
 from __future__ import annotations
 
@@ -10,8 +16,9 @@ from langgraph.graph import END, StateGraph
 from langgraph.types import interrupt, Command
 import structlog
 
+from src.nodes.analyzer import analyze
+from src.nodes.planner import plan
 from src.nodes.publisher import publish
-from src.nodes.reporter import report
 from src.nodes.researcher import research
 from src.nodes.router import route
 from src.nodes.writer import write
@@ -29,16 +36,17 @@ logger = structlog.get_logger()
 # --- Routing logic ---
 
 def _route_after_router(state: AgentState) -> str:
-    """Conditional edge: skip researcher for interactive tasks."""
+    """Conditional edge: interactive skips planner and goes straight to researcher.
+    Content/feedback go through planner first for strategic guidance."""
     if state.task_type == "interactive":
-        return "writer"
-    return "researcher"
+        return "researcher"
+    return "planner"
 
 
 def _route_after_writer(state: AgentState) -> str:
-    """Conditional edge: skip publisher for interactive tasks."""
+    """Conditional edge: interactive skips approval+analyzer, content goes to approval."""
     if state.task_type == "interactive":
-        return "reporter"
+        return END
     return "approval"
 
 
@@ -50,7 +58,7 @@ def approve(state: AgentState) -> AgentState:
     The operator can:
     - approve: continue to publisher as-is
     - edit: update the draft, then continue to publisher
-    - reject: skip publisher, go straight to reporter
+    - reject: skip publisher, go straight to analyzer
     """
     decision = interrupt({
         "task": state.task,
@@ -85,60 +93,61 @@ def approve(state: AgentState) -> AgentState:
 def _route_after_approval(state: AgentState) -> str:
     """Skip publisher if draft was rejected."""
     if state.error and "rejected" in state.error.lower():
-        return "reporter"
+        return "analyzer"
     return "publisher"
 
 
 # --- Build graphs ---
 
 def _build_graph():
-    """Build the Bekku pipeline graph with conditional routing and HIL.
+    """Build the Bekku pipeline graph with learning loop, conditional routing, and HIL.
 
-    content/feedback: router → researcher → writer → ⏸ approval → publisher → reporter
-    interactive:      router → writer → reporter (no approval needed)
+    content/feedback: router → planner → researcher → writer → ⏸ approval → publisher → analyzer
+    interactive:      router → researcher (lightweight) → writer → END
     """
     graph = StateGraph(AgentState)
 
     # Nodes
     graph.add_node("router", route)
+    graph.add_node("planner", plan)
     graph.add_node("researcher", research)
     graph.add_node("writer", write)
     graph.add_node("approval", approve)
     graph.add_node("publisher", publish)
-    graph.add_node("reporter", report)
+    graph.add_node("analyzer", analyze)
 
-    # Entry
+    # Entry: router classifies first (cheap — one small LLM call)
     graph.set_entry_point("router")
 
-    # Conditional: router → researcher or writer
+    # Conditional: router → planner (content/feedback) or researcher (interactive)
     graph.add_conditional_edges(
         "router",
         _route_after_router,
-        {"researcher": "researcher", "writer": "writer"},
+        {"planner": "planner", "researcher": "researcher"},
     )
+
+    # planner → researcher
+    graph.add_edge("planner", "researcher")
 
     # researcher always → writer
     graph.add_edge("researcher", "writer")
 
-    # Conditional: writer → approval or reporter (interactive skips approval)
+    # Conditional: writer → approval (content/feedback) or END (interactive)
     graph.add_conditional_edges(
         "writer",
         _route_after_writer,
-        {"approval": "approval", "reporter": "reporter"},
+        {"approval": "approval", END: END},
     )
 
-    # Conditional: approval → publisher or reporter (rejected skips publish)
+    # Conditional: approval → publisher or analyzer (rejected skips publish)
     graph.add_conditional_edges(
         "approval",
         _route_after_approval,
-        {"publisher": "publisher", "reporter": "reporter"},
+        {"publisher": "publisher", "analyzer": "analyzer"},
     )
 
-    # publisher always → reporter
-    graph.add_edge("publisher", "reporter")
-
-    # Finish
-    graph.set_finish_point("reporter")
+    # publisher always → analyzer
+    graph.add_edge("publisher", "analyzer")
 
     return graph.compile()
 

--- a/src/nodes/analyzer.py
+++ b/src/nodes/analyzer.py
@@ -1,0 +1,109 @@
+"""Analyzer agent node — closes the learning loop by logging outcomes and extracting rules."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import structlog
+
+from src.state import AgentState
+from src.tools.skills import append_to_skill, log_failure
+
+logger = structlog.get_logger()
+
+
+def _classify_topic(task: str) -> str:
+    """Simple keyword-based topic classification."""
+    task_lower = task.lower()
+    categories = {
+        "tutorial": ["tutorial", "guide", "how to", "integrate", "setup", "migration"],
+        "case-study": ["case study", "pattern", "real-world", "example"],
+        "feedback": ["feedback", "improve", "suggestion", "critique"],
+        "opinion": ["opinion", "future", "predict", "change", "rise of"],
+        "application": ["application", "letter", "advocate", "apply"],
+    }
+    for category, keywords in categories.items():
+        if any(kw in task_lower for kw in keywords):
+            return category
+    return "guide"
+
+
+def _determine_approval_status(state: AgentState) -> str:
+    """Determine what happened during approval."""
+    if state.error and "rejected" in state.error.lower():
+        return "rejected"
+    if state.published_url:
+        return "approved"
+    return "no-publish"
+
+
+async def analyze(state: AgentState) -> AgentState:
+    """Log structured outcome and extract learning rules from this run."""
+    logger.info("analyzer_start")
+
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    category = _classify_topic(state.task)
+    approval = _determine_approval_status(state)
+
+    # Build activity log entry
+    entry = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "task": state.task,
+        "task_type": state.task_type,
+        "category": category,
+        "published_url": state.published_url,
+        "sources_count": len(state.sources),
+        "draft_length": len(state.draft),
+        "approval": approval,
+        "error": state.error or None,
+    }
+    state.activity_log.append(entry)
+
+    # --- Log to content-performance.md ---
+    if state.task_type in ("content", "feedback"):
+        perf_entry = (
+            f"### {today} — {state.task[:80]}\n"
+            f"- **Category:** {category}\n"
+            f"- **Format:** gist\n"
+            f"- **Sources:** {len(state.sources)} sources used\n"
+            f"- **Draft length:** {len(state.draft)} chars\n"
+            f"- **Approval:** {approval}\n"
+            f"- **Published URL:** {state.published_url or 'N/A'}\n"
+            f"- **LinkedIn URL:** N/A\n"
+            f"- **LinkedIn Engagement:** pending\n"
+            f"- **Rule learned:** [pending review]"
+        )
+        append_to_skill("content-performance.md", perf_entry)
+
+    # --- Log failures with actionable rules ---
+    if state.error:
+        if "rejected" in state.error.lower():
+            log_failure(
+                what_failed=f"Draft rejected: {state.task[:60]}",
+                root_cause="Operator rejected the draft",
+                fix="Review operator feedback and adjust approach",
+                rule=f"Topic '{category}' draft was rejected — check quality bar for this category",
+            )
+        else:
+            log_failure(
+                what_failed=f"Pipeline error on: {state.task[:60]}",
+                root_cause=state.error,
+                fix="[Pending investigation]",
+                rule="[To be determined after fix]",
+            )
+
+    # --- Update knowledge skill on success ---
+    if not state.error and state.task_type == "content" and state.sources:
+        knowledge_entry = (
+            f"- [{today}] Researched: \"{state.task[:80]}\" "
+            f"— used {len(state.sources)} sources, "
+            f"produced {len(state.draft)} char draft"
+        )
+        append_to_skill("revenuecat-knowledge.md", knowledge_entry)
+
+    if not state.error and state.task_type == "feedback":
+        feedback_entry = f"- [{today}] Feedback produced: \"{state.task[:80]}\""
+        append_to_skill("product-feedback.md", feedback_entry)
+
+    logger.info("analyzer_done", **entry)
+    return state

--- a/src/nodes/planner.py
+++ b/src/nodes/planner.py
@@ -1,0 +1,64 @@
+"""Planner agent node — reads skill files and produces strategic guidance for the writer."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from openai import AsyncOpenAI
+import structlog
+
+from src.state import AgentState
+from src.tools.skills import load_skills
+
+logger = structlog.get_logger()
+
+PROMPT_PATH = Path(__file__).parent.parent / "prompts" / "planner.md"
+SKILL_MD = Path(__file__).parent.parent.parent / "skill.md"
+
+
+async def plan(state: AgentState) -> AgentState:
+    """Read skill files and produce strategic guidance for the current task."""
+    logger.info("planner_start", task=state.task[:80])
+
+    system_prompt = PROMPT_PATH.read_text()
+    skill_context = load_skills("planner")
+
+    if skill_context:
+        system_prompt += f"\n\n## Accumulated Knowledge\n\n{skill_context}"
+
+    # Load Bekku identity context
+    bekku_context = ""
+    if SKILL_MD.exists():
+        bekku_context = SKILL_MD.read_text()
+
+    parts = [f"**Task:** {state.task}"]
+    if state.task_type:
+        parts.append(f"**Task Type:** {state.task_type}")
+    if bekku_context:
+        parts.append(f"**Bekku Context:**\n\n{bekku_context}")
+
+    parts.append(
+        "Produce a strategic brief to guide the writer. "
+        "Reference specific data from the skill files above."
+    )
+
+    user_content = "\n\n".join(parts)
+
+    client = AsyncOpenAI()
+
+    try:
+        response = await client.chat.completions.create(
+            model="gpt-4o",
+            max_tokens=2048,
+            messages=[
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": user_content},
+            ],
+        )
+        state.plan = response.choices[0].message.content
+        logger.info("planner_done", plan_len=len(state.plan))
+    except Exception as e:
+        logger.error("planner_failed", error=str(e))
+        state.plan = ""  # Non-fatal — writer can proceed without a plan
+
+    return state

--- a/src/nodes/researcher.py
+++ b/src/nodes/researcher.py
@@ -110,8 +110,11 @@ async def _fetch_page(url: str) -> tuple[str, str]:
 
 
 async def research(state: AgentState) -> AgentState:
-    """Fetch RC docs, identify relevant pages, pull them, synthesize context."""
-    logger.info("researcher_start", task=state.task)
+    """Fetch RC docs, identify relevant pages, pull them, synthesize context.
+
+    For interactive tasks, uses a lightweight path (llms.txt only, no URL picking).
+    """
+    logger.info("researcher_start", task=state.task, task_type=state.task_type)
 
     # 1. Fetch llms.txt index
     try:
@@ -120,6 +123,13 @@ async def research(state: AgentState) -> AgentState:
         logger.error("llms_txt_fetch_failed", error=str(e))
         state.research_context = f"[Research failed: could not fetch llms.txt — {e}]"
         state.error = str(e)
+        return state
+
+    # Lightweight path for interactive tasks — just use llms.txt overview
+    if state.task_type == "interactive":
+        state.research_context = f"## llms.txt overview (first 4000 chars)\n\n{llms_txt[:4000]}"
+        state.sources = [get_docs_url()]
+        logger.info("researcher_done_lightweight", sources=1, context_len=len(state.research_context))
         return state
 
     # 2. Extract URLs and pick relevant ones

--- a/src/nodes/writer.py
+++ b/src/nodes/writer.py
@@ -23,6 +23,33 @@ _PROMPT_FILES = {
 }
 
 
+def _parse_social_posts(raw: str) -> dict[str, str]:
+    """Parse social post section into {platform: text} dict."""
+    posts = {}
+    current_key = None
+    current_lines: list[str] = []
+
+    for line in raw.splitlines():
+        line_lower = line.strip().lower()
+        if line_lower.startswith("**x (") or line_lower.startswith("**x:**") or "tweet" in line_lower and line.startswith("**"):
+            if current_key and current_lines:
+                posts[current_key] = "\n".join(current_lines).strip()
+            current_key = "x"
+            current_lines = []
+        elif line_lower.startswith("**linkedin"):
+            if current_key and current_lines:
+                posts[current_key] = "\n".join(current_lines).strip()
+            current_key = "linkedin"
+            current_lines = []
+        elif current_key:
+            current_lines.append(line)
+
+    if current_key and current_lines:
+        posts[current_key] = "\n".join(current_lines).strip()
+
+    return posts
+
+
 def _load_system_prompt(task_type: str) -> str:
     """Load the appropriate system prompt for the task type."""
     filename = _PROMPT_FILES.get(task_type, "writer.md")
@@ -57,6 +84,9 @@ async def write(state: AgentState) -> AgentState:
             f"**About You (Bekku) — use this to write as yourself, with real details:**\n\n"
             f"{bekku_context}"
         )
+
+    if state.plan:
+        parts.append(f"**Strategic Plan (from Planner):**\n\n{state.plan}")
 
     if state.research_context:
         parts.append(f"**Research Context:**\n\n{state.research_context}")
@@ -95,6 +125,14 @@ async def write(state: AgentState) -> AgentState:
             draft = draft[len("```md"):].strip()
             if draft.endswith("```"):
                 draft = draft[:-3].strip()
+
+        # Split off social posts if the writer included them
+        if "---SOCIAL---" in draft:
+            article, social_raw = draft.split("---SOCIAL---", 1)
+            draft = article.strip()
+            state.social_posts = _parse_social_posts(social_raw.strip())
+        else:
+            state.social_posts = {}
 
         # Fix unclosed code fences — count ``` occurrences, add closing if odd
         fence_count = draft.count("```")

--- a/src/prompts/interactive.md
+++ b/src/prompts/interactive.md
@@ -7,10 +7,11 @@ You are Bekku, an autonomous Developer Advocacy Agent built and operated by Mano
 - **Stack**: LangGraph + OpenAI (GPT-4o) + RevenueCat MCP Server
 
 ## How You Respond
-1. **Technical questions**: Answer with precision, cite RC documentation, include code examples
+1. **Technical questions**: Answer with precision, cite RC documentation, include code examples. Use the research context provided — it contains real RC docs.
 2. **Strategy questions**: Provide structured reasoning with concrete metrics and timelines
 3. **Content requests**: Draft high-quality content in real-time
 4. **Product feedback**: Base observations on actual API/MCP interactions, not speculation
+5. **Always ground answers in the research context** — you have access to real RC documentation. Reference it.
 
 ## Values Alignment (RevenueCat)
 - **Customer Obsession**: Ground everything in developer needs

--- a/src/prompts/planner.md
+++ b/src/prompts/planner.md
@@ -1,0 +1,34 @@
+You are Bekku's Planner agent. You run BEFORE any content is created to provide strategic guidance.
+
+## Your Role
+Read the accumulated skill files (past performance, failures, RC knowledge, competitive landscape, Larry playbook) and produce a strategic plan that guides the writer.
+
+## What You Do
+1. **Analyze past content** — what topics have been covered? What worked? What failed?
+2. **Identify gaps** — what important RC topics haven't been covered yet?
+3. **Apply Larry patterns** — use the Diagnostic Decision Matrix to recommend strategy
+4. **Set constraints** — based on past failures, what should the writer avoid?
+5. **Enrich the task** — add strategic context the writer wouldn't have on their own
+
+## Output Format
+Produce a concise strategic brief (not a full article). Structure it as:
+
+### Strategic Context
+- What we've published so far and how it performed
+- Gaps in topic coverage
+
+### Guidance for This Task
+- Specific angle or approach to take
+- What to avoid (based on past failures/edits)
+- Recommended format and length
+- Key sources or facts to emphasize
+
+### Rules from Past Runs
+- Any relevant rules from the failure log
+- Patterns that worked well previously
+
+## Important
+- Be concise — the writer needs guidance, not an essay
+- Be specific — "avoid placeholder code" beats "write good code"
+- If this is an autonomous/scheduled run with no specific task, PICK a topic based on gaps
+- Always reference concrete data from the skill files, not generic advice

--- a/src/prompts/writer.md
+++ b/src/prompts/writer.md
@@ -9,11 +9,23 @@ You are Bekku — an autonomous Developer Advocacy Agent. Your name means "cat" 
 - **Case Study**: Real-world usage pattern analysis, 600-1000 words
 
 ## Output Format
-Return structured output:
+Return structured output with CLEAR section markers:
 - **title**: Compelling, specific title
 - **summary**: 1-2 sentence description
 - **body**: Full markdown content
 - **tags**: 3-5 relevant tags
+
+After the main article, include a section separated by exactly this marker:
+
+---SOCIAL---
+
+Below that marker, write distribution-ready social posts:
+
+**X (Tweet/Thread):**
+A punchy tweet or short thread (max 280 chars per tweet, use 1/ 2/ 3/ for threads) that hooks developers. Tag @RevenueCat. Include a link placeholder [GIST_URL]. Think: what makes a developer stop scrolling?
+
+**LinkedIn:**
+A 3-5 sentence professional post for developer/startup audience. Lead with an insight or hot take, not "I just published..." Tag @RevenueCat. Include [GIST_URL].
 
 ## Writing Guidelines
 - Lead with value — what will the reader learn or be able to do?

--- a/src/state.py
+++ b/src/state.py
@@ -14,17 +14,21 @@ class AgentState:
     task: str = ""
     task_type: str = ""  # "content" | "interactive" | "feedback"
 
+    # Planner output
+    plan: str = ""
+
     # Researcher output
     research_context: str = ""
     sources: list[str] = field(default_factory=list)
 
     # Writer output
     draft: str = ""
+    social_posts: dict[str, str] = field(default_factory=dict)  # {"x": "...", "linkedin": "..."}
 
     # Publisher output
     published_url: str = ""
 
-    # Reporter
+    # Tracking
     activity_log: list[dict[str, Any]] = field(default_factory=list)
 
     # Error tracking

--- a/src/tools/skills.py
+++ b/src/tools/skills.py
@@ -13,6 +13,14 @@ SKILLS_DIR = Path(__file__).parent.parent.parent / "skills"
 
 # Which skill files each node should load
 NODE_SKILLS: dict[str, list[str]] = {
+    "planner": [
+        "larry-playbook.md",
+        "content-performance.md",
+        "failure-log.md",
+        "revenuecat-knowledge.md",
+        "job-description.md",
+        "competitive-landscape.md",
+    ],
     "researcher": [
         "revenuecat-knowledge.md",
         "job-description.md",
@@ -28,6 +36,10 @@ NODE_SKILLS: dict[str, list[str]] = {
         "revenuecat-knowledge.md",
         "product-feedback.md",
         "job-description.md",
+    ],
+    "analyzer": [
+        "content-performance.md",
+        "failure-log.md",
     ],
 }
 
@@ -74,6 +86,67 @@ def append_to_skill(filename: str, entry: str) -> None:
     updated = content.rstrip() + "\n\n" + entry.strip() + "\n"
     path.write_text(updated)
     logger.info("skill_updated", filename=filename, entry_length=len(entry))
+
+
+def log_engagement(
+    published_url: str,
+    linkedin_url: str,
+    impressions: int,
+    likes: int,
+    comments: int,
+    shares: int,
+) -> None:
+    """Update an existing content-performance entry with LinkedIn engagement data.
+
+    Finds the entry by published_url and appends engagement metrics.
+    """
+    path = SKILLS_DIR / "content-performance.md"
+    if not path.exists():
+        logger.warning("content_performance_not_found")
+        return
+
+    content = path.read_text()
+
+    # Find the entry block that contains this published URL
+    if published_url not in content:
+        logger.warning("entry_not_found_for_url", url=published_url)
+        # Append as a standalone engagement log
+        entry = (
+            f"\n### {date.today().isoformat()} — Engagement Update\n"
+            f"- **Published URL:** {published_url}\n"
+            f"- **LinkedIn URL:** {linkedin_url}\n"
+            f"- **LinkedIn Engagement:** {impressions} impressions / {likes} likes / {comments} comments / {shares} shares\n"
+        )
+        append_to_skill("content-performance.md", entry)
+        return
+
+    # Replace "pending" engagement line or append after published URL line
+    engagement_line = f"- **LinkedIn Engagement:** {impressions} impressions / {likes} likes / {comments} comments / {shares} shares"
+    linkedin_url_line = f"- **LinkedIn URL:** {linkedin_url}"
+
+    # Try to update existing engagement line
+    if "- **LinkedIn Engagement:** pending" in content:
+        content = content.replace(
+            "- **LinkedIn Engagement:** pending",
+            engagement_line,
+            1,  # only replace first match near this URL — good enough for now
+        )
+    elif "- **LinkedIn URL:** N/A" in content:
+        content = content.replace(
+            "- **LinkedIn URL:** N/A",
+            f"{linkedin_url_line}\n{engagement_line}",
+            1,
+        )
+    else:
+        # Append after the published URL line
+        content = content.replace(
+            f"- **Published URL:** {published_url}",
+            f"- **Published URL:** {published_url}\n{linkedin_url_line}\n{engagement_line}",
+            1,
+        )
+
+    path.write_text(content)
+    logger.info("engagement_logged", url=published_url, impressions=impressions, likes=likes)
 
 
 def log_failure(what_failed: str, root_cause: str, fix: str, rule: str) -> None:


### PR DESCRIPTION
…tribution, and GitHub Actions deployment

- Add planner node: reads all skill files, produces strategic guidance for writer
- Add analyzer node: replaces reporter, logs structured outcomes to content-performance.md
- Add social post generation: writer produces X + LinkedIn posts alongside articles
- Add engagement tracking: MK logs LinkedIn metrics via Streamlit UI or GitHub Issue comments
- Add GitHub Actions deployment: cron-triggered content generation, issue-based approval flow
- Wire new graph: router → planner → researcher → writer → approval → publisher → analyzer
- Interactive mode skips planner/analyzer, uses lightweight researcher path
- Add larry-playbook.md and content-performance.md skill files
- Add run_scheduled.py (headless runner) and run_approve.py (issue approval handler)