### PR TITLE
fix: rename GITHUB_TOKEN to GH_PAT for Actions secrets compatibility

### DIFF
--- a/.github/workflows/approve.yml
+++ b/.github/workflows/approve.yml
@@ -41,7 +41,7 @@ jobs:
         if: steps.parse.outputs.action == 'approve'
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_PAT }}
           GITHUB_REPO: ${{ github.repository }}
         run: |
           python run_approve.py \
@@ -52,7 +52,7 @@ jobs:
         if: steps.parse.outputs.action == 'reject'
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_PAT }}
           GITHUB_REPO: ${{ github.repository }}
         run: |
           python run_approve.py \
@@ -63,7 +63,7 @@ jobs:
         if: steps.parse.outputs.action == 'edit'
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_PAT }}
           GITHUB_REPO: ${{ github.repository }}
         run: |
           python run_approve.py \
@@ -74,7 +74,7 @@ jobs:
       - name: Handle engagement
         if: steps.parse.outputs.action == 'engagement'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_PAT }}
           GITHUB_REPO: ${{ github.repository }}
         run: |
           python run_approve.py \

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Generate content draft
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_PAT }}
           GITHUB_REPO: ${{ github.repository }}
         run: |
           if [ -n "${{ github.event.inputs.task }}" ]; then

--- a/run_approve.py
+++ b/run_approve.py
@@ -24,7 +24,7 @@ load_dotenv()
 
 
 def get_repo():
-    token = os.environ["GITHUB_TOKEN"]
+    token = os.environ.get("GH_TOKEN") or os.environ["GITHUB_TOKEN"]
     repo_name = os.environ.get("GITHUB_REPO", "bekku-agent/bekku-agent")
     gh = Github(token)
     return gh.get_repo(repo_name)

--- a/run_scheduled.py
+++ b/run_scheduled.py
@@ -67,7 +67,7 @@ async def generate_draft(task: str) -> dict:
 
 def create_review_issue(result: dict) -> str:
     """Create a GitHub Issue with the draft for MK to review."""
-    token = os.environ["GITHUB_TOKEN"]
+    token = os.environ.get("GH_TOKEN") or os.environ["GITHUB_TOKEN"]
     repo_name = os.environ.get("GITHUB_REPO", "bekku-agent/bekku-agent")
 
     gh = Github(token)

--- a/src/tools/github_tools.py
+++ b/src/tools/github_tools.py
@@ -12,7 +12,7 @@ logger = structlog.get_logger()
 
 def get_github_client() -> Github:
     """Create an authenticated GitHub client."""
-    token = os.environ["GITHUB_TOKEN"]
+    token = os.environ.get("GH_TOKEN") or os.environ["GITHUB_TOKEN"]
     return Github(token)
 
 


### PR DESCRIPTION
GitHub reserves the GITHUB_ prefix for secrets. Scripts fall back to GITHUB_TOKEN for local .env usage.