### PR TITLE
fix: use HTML comment markers for draft extraction instead of --- del…

### DIFF
--- a/run_approve.py
+++ b/run_approve.py
@@ -31,11 +31,10 @@ def get_repo():
 
 
 def extract_draft_from_issue(body: str) -> str:
-    """Extract the draft markdown from the issue body (between the --- markers)."""
-    parts = body.split("---")
-    if len(parts) >= 3:
-        # The draft is between the first and second --- after the metadata
-        return parts[2].strip()
+    """Extract the draft markdown from the issue body (between HTML comment markers)."""
+    match = re.search(r"<!-- DRAFT_START -->\s*(.*?)\s*<!-- DRAFT_END -->", body, re.DOTALL)
+    if match:
+        return match.group(1).strip()
     return body
 
 

--- a/run_scheduled.py
+++ b/run_scheduled.py
@@ -78,15 +78,15 @@ def create_review_issue(result: dict) -> str:
     social = result["social_posts"]
     sources = result["sources"]
 
-    # Build issue body
+    # Build issue body — use unique markers so we can extract the draft later
     body_parts = [
         "## Draft for Review\n",
         f"**Task:** {task}\n",
         f"**Type:** {result['task_type']}\n",
         f"**Sources:** {len(sources)}\n",
-        "---\n",
+        "<!-- DRAFT_START -->\n",
         draft,
-        "\n---\n",
+        "\n<!-- DRAFT_END -->\n",
     ]
 
     if social:


### PR DESCRIPTION
…imiters

The article content contains --- which broke the split-based extraction. Using <!-- DRAFT_START --> and <!-- DRAFT_END --> markers instead.